### PR TITLE
Fix memory leak for multilined text objects

### DIFF
--- a/gwen/src/Controls/Text.cpp
+++ b/gwen/src/Controls/Text.cpp
@@ -239,9 +239,9 @@ void Text::RefreshSizeWrap()
 {
 	RemoveAllChildren();
 
-        for (TextLines::iterator it = m_Lines.begin(); it != m_Lines.end(); ++it) {
-            delete *it;
-        }
+	for (TextLines::iterator it = m_Lines.begin(); it != m_Lines.end(); ++it) {
+		delete *it;
+	}
 	m_Lines.clear();
 
 	std::vector<Gwen::UnicodeString> words;


### PR DESCRIPTION
This changes fix https://github.com/garrynewman/GWEN/issues/16 and https://github.com/garrynewman/GWEN/issues/19
