### PR TITLE
Fix the SFML renderer to work with non-MSVC compilers

### DIFF
--- a/gwen/Renderers/SFML/SFML.cpp
+++ b/gwen/Renderers/SFML/SFML.cpp
@@ -6,6 +6,7 @@
 #include "Gwen/Renderers/SFML.h"
 #include <SFML/Graphics.hpp>
 #include <GL/gl.h>
+#include <cmath>
 
 namespace Gwen 
 {
@@ -78,7 +79,7 @@ namespace Gwen
 
             sf::Vertex vert( sf::Vector2f( x, y ), m_Color );
 
-            m_Target.draw( &vert, 1, sf::PrimitiveType::Points );
+            m_Target.draw( &vert, 1, sf::Points );
 #else
             Base::DrawPixel( x, y );
 #endif


### PR DESCRIPTION
In Renderers/SFML.cpp:

 m_Target.draw( &vert, 1, sf::PrimitiveType::Points );

should be:

 m_Target.draw( &vert, 1, sf::Points );

as Scoped Enums are part of C++11 / Microsoft Extensions and c++11 is not defined in the premake files, resulting in a "error: 'sf::PrimitiveType` is not a class or namespace" error with G++ 4.4.5.

I also had to add:
# include &lt;cmath>

to the top of SFML.cpp because fabs was not declared.
