### PR TITLE
Fix for TextBoxes not moving the text when caret needs to move

### DIFF
--- a/gwen/include/Gwen/Controls/TextBox.h
+++ b/gwen/include/Gwen/Controls/TextBox.h
@@ -24,6 +24,7 @@ namespace Gwen
 				virtual void Render( Skin::Base* skin );
 				virtual void RenderFocus( Gwen::Skin::Base* /*skin*/){};
 				virtual void Layout( Skin::Base* skin );
+				virtual void PostLayout( Skin::Base* skin );
 
 				#ifndef GWEN_NO_ANIMATION
 				virtual void UpdateCaretColor();

--- a/gwen/src/Controls/TextBox.cpp
+++ b/gwen/src/Controls/TextBox.cpp
@@ -410,7 +410,7 @@ void TextBox::MakeCaratVisible()
 	}
 
 	// The ideal position is for the carat to be right in the middle
-	int idealx = -iCaratPos + Width() * 0.5f;;
+	int idealx = -iCaratPos + Width() * 0.5f;
 
 	// Don't show too much whitespace to the right
 	if ( idealx + m_Text->Width() < Width() - GetPadding().right )
@@ -429,6 +429,10 @@ void TextBox::Layout( Skin::Base* skin )
 	BaseClass::Layout( skin );
 
 	RefreshCursorBounds();
+}
+
+void TextBox::PostLayout( Skin::Base* skin )
+{
 }
 
 void TextBox::OnTextChanged()


### PR DESCRIPTION
## Bug

If the caret moves out of the TextBox's range or adding characters that exceed the textbox's visible space, the text wouldn't move.
## Fix

Adds empty PostLayout() in TextBox class to avoid Label's PostLayout from being called. Otherwise the text's position will always be set to a fixed position defined by the alignment.
## Misc changes
- Removed extraneous semicolon in TextBox::MakeCaratVisible()
- Added newline in TextBox.cpp to avoid GNU compiler warnings
