### PR TITLE
Fix keyboard focus not being reset when no control with keyboard input is selected

### DIFF
--- a/gwen/src/inputhandler.cpp
+++ b/gwen/src/inputhandler.cpp
@@ -228,7 +228,8 @@ bool Gwen::Input::OnMouseClicked( Controls::Base* pCanvas, int iMouseButton, boo
 	{
 		if (!FindKeyboardFocus( Gwen::HoveredControl ))
         {
-            Gwen::KeyboardFocus = NULL;
+			if (Gwen::KeyboardFocus)
+				Gwen::KeyboardFocus->Blur();
         }
 	}
 


### PR DESCRIPTION
When a text control is selected, and then you click on an empty canvas (or any item that doesn't take keyboard input), the KeyboardFocus isn't reset. So when you then type, that control still receives input.

This patch checks and resets the KeyboardFocus to null if there is no valid focus.
