### PR TITLE
Make SelectItem public so that items don't have to be uniquely named

### DIFF
--- a/gwen/include/Gwen/Controls/ComboBox.h
+++ b/gwen/include/Gwen/Controls/ComboBox.h
@@ -30,6 +30,7 @@ namespace Gwen
 				virtual void Layout( Skin::Base* skin );
 				virtual void UpdateColours();
 
+                virtual void SelectItem( MenuItem* pItem, bool bFireChangeEvents = true );
 				virtual void SelectItemByName( const Gwen::String& name, bool bFireChangeEvents = true );
 				virtual Gwen::Controls::Label* GetSelectedItem();
 
@@ -55,8 +56,6 @@ namespace Gwen
 				Gwen::Event::Caller	onSelection;
 
 			protected:
-
-				void SelectItem( MenuItem* pItem );
 
 				Menu* m_Menu;
 				MenuItem* m_SelectedItem;

--- a/gwen/src/Controls/ComboBox.cpp
+++ b/gwen/src/Controls/ComboBox.cpp
@@ -127,7 +127,7 @@ void ComboBox::ClearItems()
 	}
 }
 
-void ComboBox::SelectItem( MenuItem* pItem )
+void ComboBox::SelectItem( MenuItem* pItem, bool bFireChangeEvents )
 {
 	if ( m_SelectedItem == pItem ) return;
 
@@ -135,6 +135,12 @@ void ComboBox::SelectItem( MenuItem* pItem )
 	SetText( m_SelectedItem->GetText() );
 	m_Menu->SetHidden( true );
 	Invalidate();
+    
+    if (bFireChangeEvents)
+    {
+        onSelection.Call(this);
+        Focus();
+    }
 }
 
 void ComboBox::OnItemSelected( Controls::Base* pControl )
@@ -144,9 +150,6 @@ void ComboBox::OnItemSelected( Controls::Base* pControl )
 	if ( !pItem ) return;
 
 	SelectItem( pItem );
-
-	onSelection.Call( this );
-	Focus();
 }
 
 void ComboBox::SelectItemByName( const Gwen::String& name, bool bFireChangeEvents )
@@ -160,10 +163,7 @@ void ComboBox::SelectItemByName( const Gwen::String& name, bool bFireChangeEvent
 
 		if ( pChild->GetName() == name )
 		{
-			if ( bFireChangeEvents )
-				return OnItemSelected( pChild );
-
-			return SelectItem( pChild );
+			return SelectItem( pChild, bFireChangeEvents );
 		}
 
 		++it;


### PR DESCRIPTION
I could be missing something here, so this pull request might not be valid, but at present all the items within a combo box have to be uniquely named. In my use case I would have to generate a random string in order to do this, rather than just select the MenuItem I just added (it's returned from AddItem).

This patch makes SelectItem public (and patches up calls to maintain the existing event propagation), so that it can be called by a user.
