### PR TITLE
Fix non-virtual destructor warnings

### DIFF
--- a/gwen/include/Gwen/UserData.h
+++ b/gwen/include/Gwen/UserData.h
@@ -38,6 +38,7 @@ namespace Gwen
 	{
 			struct ValueBase
 			{
+				virtual ~ValueBase() {}
 				virtual void DeleteThis() = 0;
 			};
 


### PR DESCRIPTION
The attached commit fixes the following warnings under clang by adding a virtual destructor to ValueBase.

/gwen/gwen/include/Gwen/UserData.h:55:6: Delete called on 'Gwen::UserDataStorage::Valuestd::__1::basic_string<char >' that has virtual functions but non-virtual destructor
