### PR TITLE
Fixes an overloaded virtual function warning

### DIFF
--- a/gwen/include/Gwen/Controls/Canvas.h
+++ b/gwen/include/Gwen/Controls/Canvas.h
@@ -94,7 +94,7 @@ namespace Gwen
 				Controls::Base::List	m_DeleteList;
 				std::set< Controls::Base* > m_DeleteSet;
 				friend class Controls::Base;
-				void PreDelete( Controls::Base* );
+				void PreDeleteCanvas( Controls::Base* );
 
 				bool			m_bDrawBackground;
 				Gwen::Color		m_BackgroundColor;

--- a/gwen/src/Controls/Base.cpp
+++ b/gwen/src/Controls/Base.cpp
@@ -57,7 +57,7 @@ Base::~Base()
 		Canvas* canvas = GetCanvas();
 
 		if ( canvas )
-		{ canvas->PreDelete( this ); }
+		{ canvas->PreDeleteCanvas( this ); }
 	}
 	Base::List::iterator iter = Children.begin();
 

--- a/gwen/src/Controls/Canvas.cpp
+++ b/gwen/src/Controls/Canvas.cpp
@@ -116,7 +116,7 @@ void Canvas::AddDelayedDelete( Gwen::Controls::Base* pControl )
 	}
 }
 
-void Canvas::PreDelete( Controls::Base* pControl )
+void Canvas::PreDeleteCanvas( Controls::Base* pControl )
 {
 	if ( m_bAnyDelete )
 	{


### PR DESCRIPTION
I'm just trying to clean up all the warnings that create warnings in my project (I'll look at fixing up the rest too, if you don't have any issues with it?)

The attached commit fixes the following warning -

/Users/aeonflame/Development/pixelballoon/roborush/pixelboost/libs/gwen/gwen/include/Gwen/Controls/Canvas.h:97:10: 'Gwen::Controls::Canvas::PreDelete' hides overloaded virtual function

Since this PreDelete function isn't virtual and appears to be a specialisation for Canvas I have renamed it to PreDeleteCanvas. If you have any other preferred name then let me know.
