### PR TITLE
Fixed Menus resizing themselves to fit the canvas, based on their position relative to their parents instead of the canvas.

### DIFF
--- a/gwen/Renderers/SFML2/SFML2.cpp
+++ b/gwen/Renderers/SFML2/SFML2.cpp
@@ -227,7 +227,7 @@ Gwen::Point Gwen::Renderer::SFML2::MeasureText( Gwen::Font* pFont, const Gwen::U
 	sfStr.setScale( Scale(), Scale() );
 	sfStr.setCharacterSize( pFont->realsize );
 	sf::FloatRect sz = sfStr.getLocalBounds();
-	return Gwen::Point( sz.left + sz.width, sz.top + sz.height );
+	return Gwen::Point( sz.left + sz.width, pFont->realsize * Scale() );
 }
 
 void Gwen::Renderer::SFML2::LoadTexture( Gwen::Texture* pTexture )

--- a/gwen/src/Controls/Menu.cpp
+++ b/gwen/src/Controls/Menu.cpp
@@ -52,8 +52,8 @@ void Menu::Layout( Skin::Base* skin )
 		childrenHeight += pChild->Height();
 	}
 
-	if ( Y() + childrenHeight > GetCanvas()->Height() )
-	{ childrenHeight = GetCanvas()->Height() - Y(); }
+	if (LocalPosToCanvas().y + childrenHeight > GetCanvas()->Height() )
+	{ childrenHeight = GetCanvas()->Height() - LocalPosToCanvas().y; }
 
 	SetSize( Width(), childrenHeight );
 	BaseClass::Layout( skin );


### PR DESCRIPTION
Fixed Menus rendering only as shadows when drawing to a parent with negative Y-coordinates relative to its canvas.

The Menu::Layout function alters the height of the menu to fit the canvas, but uses only the coordinate relative to its parent to check if it fits, instead of the bounds relative to the canvas.

The problem was resolved by using LocalToCanvas() in place of Y() for comparing the position of the menu relative to the canvas.


Fixed the SFML2 renderer returning a height of 0 when MeasureText is called with an empty space (as is done in the multi-line label), resulting in the multi-line label sample rendering all the lines superpositioned.

The SFML2 renderer and OpenGL renderer now returns matching height values for strings. 
Additionally, I noticed that prior to this fix the SFML2 renderer took newlines into account when calculating text height, so a string like "X\nX" would return a height more than double that of what "X" would yield. This is not the case for the OpenGL renderer, so I'm unsure of whether this is intended or not.