### PR TITLE
Fix: throw of an uncontrolled std::out_of_range exception in RichLabel.cpp

### DIFF
--- a/gwen/src/Controls/RichLabel.cpp
+++ b/gwen/src/Controls/RichLabel.cpp
@@ -104,6 +104,7 @@ void RichLabel::SplitLabel( const Gwen::UnicodeString & text, Gwen::Font* pFont,
 		strNewString += lst[i];
 	}
 
+	if ( strNewString.size() >= text.size() ) return;
 	Gwen::UnicodeString LeftOver = text.substr( strNewString.size() + 1 );
 	return SplitLabel( LeftOver, pFont, txt, x, y, lineheight );
 }


### PR DESCRIPTION
`std::string::substr` throws `std::out_of_range` if starting position is bigger than length of a string. So, it's necessary to check the position before the call.
