### PR TITLE
Repostion Slider Bar when Slider size changes

### DIFF
--- a/gwen/include/Gwen/Controls/Slider.h
+++ b/gwen/include/Gwen/Controls/Slider.h
@@ -71,9 +71,10 @@ namespace Gwen
 			protected:
 
 				virtual void SetValueInternal( float fVal );
-				virtual void UpdateBarFromValue() = 0;
+				virtual void UpdateBarFromValue(){};
 
 				ControlsInternal::SliderBar* m_SliderBar;
+				void OnBoundsChanged( Gwen::Rect oldBounds );
 				bool m_bClampToNotches;
 				int m_iNumNotches;
 				float m_fValue;

--- a/gwen/src/Controls/Slider.cpp
+++ b/gwen/src/Controls/Slider.cpp
@@ -100,3 +100,9 @@ void Slider::RenderFocus( Gwen::Skin::Base* skin )
 
 	skin->DrawKeyboardHighlight( this, GetRenderBounds(), 0 );
 }
+
+void Slider::OnBoundsChanged(Gwen::Rect oldBounds)
+{
+	BaseClass::OnBoundsChanged( oldBounds );
+	UpdateBarFromValue();
+}


### PR DESCRIPTION
Reposition Slider Bar when Slider size changes by adding
Slider:OnBoundsChanged(). Had to add empty body for
UpdateBarFromValue, because it may be called from constructor.
(Should fix that, but Gwen seems to end up calling virtual
functions from constructors also otherwise.)
