### PR TITLE
Fixed array out of range in OnMouseMoved

### DIFF
--- a/gwen/src/inputhandler.cpp
+++ b/gwen/src/inputhandler.cpp
@@ -204,7 +204,7 @@ bool Gwen::Input::OnMouseClicked( Controls::Base* pCanvas, int iMouseButton, boo
 
 	if ( Gwen::HoveredControl == pCanvas ) { return false; }
 
-	if ( iMouseButton > MAX_MOUSE_BUTTONS )
+	if ( iMouseButton >= MAX_MOUSE_BUTTONS )
 	{ return false; }
 
 	if ( iMouseButton == 0 )		{ KeyData.LeftMouseDown = bDown; }


### PR DESCRIPTION
parameter iMouseButton was not properly checked before it was
used for indexing g_fLastClickTime.
