### PR TITLE
Replace wstring::pop_back with a resize

### DIFF
--- a/gwen/src/Controls/Text.cpp
+++ b/gwen/src/Controls/Text.cpp
@@ -255,7 +255,7 @@ void Text::SplitWords(const Gwen::UnicodeString &s, std::vector<Gwen::UnicodeStr
 		{
 			int addSum = GetPadding().left+GetPadding().right;
 			//split words
-			str.pop_back();
+			str.resize( str.size() - 1 );
 			elems.push_back( str );
 			str.clear();
 			--i;


### PR DESCRIPTION
string::pop_back is a C++11 feature, resize(size - 1) should be functionally identical and does not require C++11