### PR TITLE
Premake script fix to enable multi-processor compilation for Visual Studio

### DIFF
--- a/gwen/Projects/premake4.lua
+++ b/gwen/Projects/premake4.lua
@@ -16,7 +16,9 @@ solution "GWEN"
 	}
 
 	if ( _ACTION == "vs2010" or _ACTION=="vs2008" ) then
+		-- Enable multiprocessor compilation (requires Minimal Rebuild to be disabled)
 		buildoptions { "/MP"  }
+		flags { "NoMinimalRebuild" }
 	end
 
 


### PR DESCRIPTION
Apparently the Visual Studio solution generated by premake was not building with multiple cores despite the script adding the /MP flag. This was due to the /Gm (Minimal Rebuild) flag still being enabled.  With the flag now disabled in the premake script, the generated Visual Studio solution can now properly build with multiple cores.